### PR TITLE
Health Connect migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## FeelFine - activity tracker app
 
-Application to track your fitness activities with [Google Fit API](https://developers.google.com/fit "Google Fit API").
+Application to track your fitness activities with [Health Connect](https://developer.android.com/health-and-fitness/guides/health-connect "Health Connect") and [Google Fit](https://developers.google.com/fit "Google Fit") APIs.
 - Kotlin
 - Jetpack Compose
 - [Koin](https://github.com/InsertKoinIO/koin "Koin") for DI
@@ -36,7 +36,7 @@ Four simple onboarding steps to pick your name, gender, weight and birthday.
 
 <img src="https://github.com/feelsoftware/FeelFine/raw/main/readme/score_1.png" width="180" height="360" /> <img src="https://github.com/feelsoftware/FeelFine/raw/main/readme/score_2.png" width="180" height="360" /> <img src="https://github.com/feelsoftware/FeelFine/raw/main/readme/score_3.png" width="180" height="360" /> <img src="https://github.com/feelsoftware/FeelFine/raw/main/readme/score_4.png" width="180" height="360" />
 
-A user’s data as steps, sleep, biking, running and other activities synced via [Google Fit API](https://developers.google.com/fit "Google Fit API"). User has an every day score, based on his own metrics.
+Users data as steps, sleep, walking, running and other combined activities are synced via [Health Connect](https://developer.android.com/health-and-fitness/guides/health-connect "Health Connect") or [Google Fit](https://developers.google.com/fit "Google Fit") APIs. Users have an every day score, based on their own metrics.
 
 
 ------------
@@ -46,7 +46,7 @@ A user’s data as steps, sleep, biking, running and other activities synced via
 
 <img src="https://github.com/feelsoftware/FeelFine/raw/main/readme/statistic_1.png" width="180" height="360" /> <img src="https://github.com/feelsoftware/FeelFine/raw/main/readme/statistic_2.png" width="180" height="360" /> <img src="https://github.com/feelsoftware/FeelFine/raw/main/readme/statistic_3.png" width="180" height="360" />
 
-Users could observe week/month/custom range activities statistics. 
+Users could observe week/month/custom range activities statistics.
 
 
 ------------
@@ -56,7 +56,7 @@ Users could observe week/month/custom range activities statistics.
 
 <img src="https://github.com/feelsoftware/FeelFine/raw/main/readme/mood.png" width="180" height="360" />
 
-We are asking each day 'How are you?' for the mood score with 9 options for users.
+Every day we are asking users 'How are you?' for the mood score with 9 options.
 
 
 ------------
@@ -68,3 +68,13 @@ We are asking each day 'How are you?' for the mood score with 9 options for user
 
 User profile with wage, age and goals (steps, sleep, activity) customizations.
 
+
+------------
+
+
+### What's next
+- Migrate to Kotlin Coroutines from RxJava
+- Migrate to Compose
+- Migrate to Kotlin Multiplatform  (use cross-platform library https://github.com/vitoksmile/HealthKMP)
+- Night theme
+- Edit goals

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         applicationId = "com.feelsoftware.feelfine"
-        minSdk = 23
+        minSdk = 28
         //noinspection EditedTargetSdkVersion
         targetSdk = 35
         versionCode = props.getProperty("versionCode").toInt()
@@ -81,6 +81,7 @@ android {
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.datetime)
 
     implementation(libs.core.ktx)
     implementation(libs.appcompat)
@@ -116,6 +117,7 @@ dependencies {
     implementation(libs.firebase.crashlytics.ktx)
 
     // Google Fit
+    implementation(libs.health.connect)
     implementation(libs.play.services.fitness)
     implementation(libs.google.api.client)
     implementation(libs.google.api.client.android)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,14 @@
         android:name="com.google.android.gms.permission.AD_ID"
         tools:node="remove" />
 
+    <uses-permission android:name="android.permission.health.READ_EXERCISE" />
+    <uses-permission android:name="android.permission.health.READ_SLEEP" />
+    <uses-permission android:name="android.permission.health.READ_STEPS" />
+
+    <queries>
+        <package android:name="com.google.android.apps.healthdata" />
+    </queries>
+
     <application
         android:name=".FeelFineApplication"
         android:allowBackup="false"
@@ -28,6 +36,30 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- For supported versions through Android 13, create an activity to show the rationale
+             of Health Connect permissions once users click the privacy policy link. -->
+        <activity
+            android:name=".permission.PermissionsRationaleActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+            </intent-filter>
+        </activity>
+
+        <!-- For versions starting Android 14, create an activity alias to show the rationale
+       of Health Connect permissions once users click the privacy policy link. -->
+        <activity-alias
+            android:name="ViewPermissionUsageActivity"
+            android:exported="true"
+            android:permission="android.permission.START_VIEW_PERMISSION_USAGE"
+            android:targetActivity=".permission.PermissionsRationaleActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
+            </intent-filter>
+        </activity-alias>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/feelsoftware/feelfine/di/KoinInit.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/di/KoinInit.kt
@@ -1,6 +1,7 @@
 package com.feelsoftware.feelfine.di
 
 import android.app.Application
+import com.feelsoftware.feelfine.fit.FitPermissionManager
 import com.feelsoftware.feelfine.ui.onboarding.onboardingModule
 import com.feelsoftware.feelfine.utils.ActivityEngine
 import org.koin.android.ext.koin.androidContext
@@ -21,7 +22,10 @@ object KoinInit {
                 utilsModule,
                 onboardingModule,
             )
+            // FIXME: ActivityEngine to initialize ActivityLifecycleCallbacks
             koin.get<ActivityEngine>()
+            // FIXME: FitPermissionManager to initialize HealthConnectFitPermissionManagerWrapper#activityEngine
+            koin.get<FitPermissionManager>()
         }
     }
 }

--- a/app/src/main/java/com/feelsoftware/feelfine/di/fit.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/di/fit.kt
@@ -5,57 +5,112 @@ package com.feelsoftware.feelfine.di
 import com.feelsoftware.feelfine.data.db.dao.ActivityDao
 import com.feelsoftware.feelfine.data.db.dao.SleepDao
 import com.feelsoftware.feelfine.data.db.dao.StepsDao
-import com.feelsoftware.feelfine.data.repository.*
+import com.feelsoftware.feelfine.data.repository.ActivityDataRepository
+import com.feelsoftware.feelfine.data.repository.ActivityRemoteDataSource
+import com.feelsoftware.feelfine.data.repository.SleepDataRepository
+import com.feelsoftware.feelfine.data.repository.SleepRemoteDataSource
+import com.feelsoftware.feelfine.data.repository.StepsDataRepository
+import com.feelsoftware.feelfine.data.repository.StepsRemoteDataSource
+import com.feelsoftware.feelfine.data.repository.UserRepository
 import com.feelsoftware.feelfine.fit.FitPermissionManager
 import com.feelsoftware.feelfine.fit.FitRepository
 import com.feelsoftware.feelfine.fit.GoogleFitPermissionManager
 import com.feelsoftware.feelfine.fit.GoogleFitRepository
+import com.feelsoftware.feelfine.fit.HealthConnectClientProvider
+import com.feelsoftware.feelfine.fit.HealthConnectClientProviderImpl
+import com.feelsoftware.feelfine.fit.HealthConnectFitPermissionManagerWrapper
+import com.feelsoftware.feelfine.fit.HealthConnectFitRepositoryWrapper
+import com.feelsoftware.feelfine.fit.HealthConnectPermissionManager
+import com.feelsoftware.feelfine.fit.HealthConnectPermissionManagerImpl
+import com.feelsoftware.feelfine.fit.HealthConnectRepository
+import com.feelsoftware.feelfine.fit.HealthConnectRepositoryImpl
 import com.feelsoftware.feelfine.fit.mock.MockFitRepository
 import com.feelsoftware.feelfine.fit.usecase.GetFitDataUseCase
 import com.feelsoftware.feelfine.utils.ActivityEngine
+import org.koin.android.ext.koin.androidApplication
+import org.koin.core.scope.Scope
 import org.koin.dsl.module
 
 val fitModule = module {
+    single<HealthConnectClientProvider> {
+        HealthConnectClientProviderImpl(
+            context = androidApplication(),
+        )
+    }
+    single<HealthConnectPermissionManager> {
+        HealthConnectPermissionManagerImpl(
+            clientProvider = get<HealthConnectClientProvider>(),
+        )
+    }
+    factory<HealthConnectRepository> {
+        HealthConnectRepositoryImpl(
+            clientProvider = get<HealthConnectClientProvider>(),
+            permissionManager = get<HealthConnectPermissionManager>(),
+        )
+    }
     factory<FitRepository> {
         val profile = get<UserRepository>().getProfileLegacy().firstOrError().blockingGet()
         if (profile.isDemo) {
             MockFitRepository()
         } else {
-            GoogleFitRepository(get<ActivityEngine>(), get<FitPermissionManager>())
+            if (hasHealthConnect) {
+                HealthConnectFitRepositoryWrapper(
+                    repository = get<HealthConnectRepository>(),
+                )
+            } else {
+                GoogleFitRepository(
+                    activityEngine = get<ActivityEngine>(),
+                    permissionManager = get<FitPermissionManager>(),
+                )
+            }
         }
     }
     single<FitPermissionManager> {
-        GoogleFitPermissionManager(
-            get<ActivityDao>(),
-            get<ActivityEngine>(),
-            get<SleepDao>(),
-            get<StepsDao>(),
-            get<UserRepository>(),
-        )
+        if (hasHealthConnect) {
+            HealthConnectFitPermissionManagerWrapper(
+                activityDao = get<ActivityDao>(),
+                activityEngine = get<ActivityEngine>(),
+                permissionManager = get<HealthConnectPermissionManager>(),
+                sleepDao = get<SleepDao>(),
+                stepsDao = get<StepsDao>(),
+                userRepository = get<UserRepository>(),
+            )
+        } else {
+            GoogleFitPermissionManager(
+                activityDao = get<ActivityDao>(),
+                activityEngine = get<ActivityEngine>(),
+                sleepDao = get<SleepDao>(),
+                stepsDao = get<StepsDao>(),
+                userRepository = get<UserRepository>(),
+            )
+        }
     }
     factory<GetFitDataUseCase> {
         GetFitDataUseCase(
-            get<StepsDataRepository>(),
-            get<SleepDataRepository>(),
-            get<ActivityDataRepository>(),
+            stepsRepository = get<StepsDataRepository>(),
+            sleepRepository = get<SleepDataRepository>(),
+            activityRepository = get<ActivityDataRepository>(),
         )
     }
     factory<StepsDataRepository> {
         StepsDataRepository(
-            get<StepsDao>(),
-            StepsRemoteDataSource(get<FitRepository>())
+            localDataSource = get<StepsDao>(),
+            remoteDataSource = StepsRemoteDataSource(get<FitRepository>())
         )
     }
     factory<SleepDataRepository> {
         SleepDataRepository(
-            get<SleepDao>(),
-            SleepRemoteDataSource(get<FitRepository>())
+            localDataSource = get<SleepDao>(),
+            remoteDataSource = SleepRemoteDataSource(get<FitRepository>())
         )
     }
     factory<ActivityDataRepository> {
         ActivityDataRepository(
-            get<ActivityDao>(),
-            ActivityRemoteDataSource(get<FitRepository>())
+            localDataSource = get<ActivityDao>(),
+            remoteDataSource = ActivityRemoteDataSource(get<FitRepository>())
         )
     }
 }
+
+private inline val Scope.hasHealthConnect: Boolean
+    get() = get<HealthConnectClientProvider>().invoke().getOrNull() != null

--- a/app/src/main/java/com/feelsoftware/feelfine/fit/FitPermissionManager.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/fit/FitPermissionManager.kt
@@ -35,6 +35,7 @@ interface FitPermissionManager {
 
 private const val REQUEST_CODE = 1717
 
+@Deprecated("Migrate to HealthConnectPermissionManager")
 class GoogleFitPermissionManager(
     private val activityDao: ActivityDao,
     private val activityEngine: ActivityEngine,

--- a/app/src/main/java/com/feelsoftware/feelfine/fit/FitRepository.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/fit/FitRepository.kt
@@ -34,6 +34,7 @@ interface FitRepository {
     fun getActivity(startTime: Date, endTime: Date): Single<List<ActivityInfo>>
 }
 
+@Deprecated("Migrate to HealthConnectRepository")
 class GoogleFitRepository(
     private val activityEngine: ActivityEngine,
     private val permissionManager: FitPermissionManager,

--- a/app/src/main/java/com/feelsoftware/feelfine/fit/HealthConnectClientProvider.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/fit/HealthConnectClientProvider.kt
@@ -1,0 +1,72 @@
+package com.feelsoftware.feelfine.fit
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.health.connect.client.HealthConnectClient
+
+/**
+ * Provide instance of [HealthConnectClient].
+ */
+interface HealthConnectClientProvider {
+
+    /**
+     * @return [Error] when `Result.failure`.
+     */
+    operator fun invoke(): Result<HealthConnectClient>
+
+    /**
+     * Call to perform update after `invoke()` returned `Error.UpdateRequired`.
+     */
+    suspend fun performUpdate(): Result<Unit>
+
+    @Suppress("JavaIoSerializableObjectMustHaveReadResolve")
+    sealed class Error : Throwable() {
+        data object UpdateRequired : Error()
+
+        data object NotAvailable : Error()
+    }
+}
+
+class HealthConnectClientProviderImpl(
+    private val context: Context,
+) : HealthConnectClientProvider {
+
+    private var client: HealthConnectClient? = null
+
+    override fun invoke(): Result<HealthConnectClient> = runCatching {
+        when (HealthConnectClient.getSdkStatus(context, PROVIDER_PACKAGE_NAME)) {
+            HealthConnectClient.SDK_AVAILABLE -> {
+                client ?: synchronized(this) {
+                    HealthConnectClient.getOrCreate(context).also { client = it }
+                }
+            }
+
+            HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED -> {
+                throw HealthConnectClientProvider.Error.UpdateRequired
+            }
+
+            else -> {
+                throw HealthConnectClientProvider.Error.NotAvailable
+            }
+        }
+    }
+
+    override suspend fun performUpdate(): Result<Unit> = runCatching {
+        // Redirect to package installer to find a provider
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setPackage("com.android.vending")
+            data = Uri.parse(
+                "market://details?id=$PROVIDER_PACKAGE_NAME&url=healthconnect%3A%2F%2Fonboarding"
+            )
+            putExtra("overlay", true)
+            putExtra("callerId", context.packageName)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        context.startActivity(intent)
+    }
+
+    private companion object {
+        private const val PROVIDER_PACKAGE_NAME = "com.google.android.apps.healthdata"
+    }
+}

--- a/app/src/main/java/com/feelsoftware/feelfine/fit/HealthConnectPermissionManager.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/fit/HealthConnectPermissionManager.kt
@@ -1,0 +1,110 @@
+package com.feelsoftware.feelfine.fit
+
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.health.connect.client.PermissionController
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.records.StepsRecord
+import androidx.lifecycle.lifecycleScope
+import kotlin.coroutines.resume
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+interface HealthConnectPermissionManager {
+
+    fun init(activity: ComponentActivity)
+
+    fun dispose()
+
+    fun hasPermission(): StateFlow<Boolean>
+
+    suspend fun requestPermission(): Result<Boolean>
+}
+
+class HealthConnectPermissionManagerImpl(
+    private val clientProvider: HealthConnectClientProvider,
+) : HealthConnectPermissionManager {
+
+    private val requiredPermissions: Set<String> = setOf(
+        HealthPermission.getReadPermission(ExerciseSessionRecord::class),
+        HealthPermission.getReadPermission(SleepSessionRecord::class),
+        HealthPermission.getReadPermission(StepsRecord::class),
+    )
+
+    private var activity: ComponentActivity? = null
+    private var permissionsLauncher: ActivityResultLauncher<Set<String>>? = null
+    private var requestPermissionContinuation: CancellableContinuation<Boolean>? = null
+
+    private inline val coroutineScope: CoroutineScope?
+        get() = activity?.lifecycleScope
+
+    private val hasPermissionFlow = MutableStateFlow(false)
+
+    override fun init(activity: ComponentActivity) {
+        this.activity = activity
+        permissionsLauncher = activity.registerForActivityResult(
+            PermissionController.createRequestPermissionResultContract()
+        ) { granted ->
+            val hasPermission = granted.containsAll(requiredPermissions)
+            hasPermissionFlow.update { hasPermission }
+            requestPermissionContinuation?.resume(hasPermission)
+            requestPermissionContinuation = null
+        }
+    }
+
+    override fun dispose() {
+        activity = null
+        permissionsLauncher = null
+        requestPermissionContinuation?.cancel()
+        requestPermissionContinuation = null
+    }
+
+    override fun hasPermission(): StateFlow<Boolean> {
+        coroutineScope?.launch { hasPermissionInternal() }
+        return hasPermissionFlow.asStateFlow()
+    }
+
+    override suspend fun requestPermission(): Result<Boolean> {
+        return hasPermissionInternal()
+            .mapCatching { hasPermission ->
+                if (hasPermission) {
+                    // Permissions already granted
+                    true
+                } else {
+                    // Lack of required permissions
+                    requestPermissionContinuation?.cancel()
+                    suspendCancellableCoroutine {
+                        requestPermissionContinuation = it
+
+                        requireNotNull(permissionsLauncher) {
+                            "Permissions launcher is not ready, did you call init?"
+                        }.launch(requiredPermissions)
+                    }
+                }
+            }
+    }
+
+    private suspend fun hasPermissionInternal(): Result<Boolean> {
+        return clientProvider()
+            .mapCatching { client ->
+                client.permissionController.getGrantedPermissions()
+            }
+            .mapCatching { grantedPermissions ->
+                grantedPermissions.containsAll(requiredPermissions)
+            }
+            .onSuccess {
+                hasPermissionFlow.value = it
+            }
+            .onFailure {
+                hasPermissionFlow.value = false
+            }
+    }
+}

--- a/app/src/main/java/com/feelsoftware/feelfine/fit/HealthConnectRepository.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/fit/HealthConnectRepository.kt
@@ -1,0 +1,186 @@
+@file:Suppress("SameParameterValue")
+
+package com.feelsoftware.feelfine.fit
+
+import androidx.health.connect.client.aggregate.AggregateMetric
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.AggregateRequest
+import androidx.health.connect.client.request.ReadRecordsRequest
+import androidx.health.connect.client.time.TimeRangeFilter
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.flow.first
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.atTime
+import kotlinx.datetime.minus
+import kotlinx.datetime.toJavaLocalDateTime
+
+data class Activity(
+    val date: LocalDate,
+    val walking: Duration,
+    val running: Duration,
+    val other: Duration,
+)
+
+data class Sleep(
+    val date: LocalDate,
+    val lightSleep: Duration,
+    val deepSleep: Duration,
+    val awake: Duration,
+    val outOfBed: Duration,
+)
+
+data class Steps(
+    val date: LocalDate,
+    val count: Long,
+)
+
+interface HealthConnectRepository {
+
+    suspend fun getActivity(date: LocalDate): Result<Activity>
+
+    suspend fun getSleep(date: LocalDate): Result<Sleep>
+
+    suspend fun getSteps(date: LocalDate): Result<Steps>
+}
+
+class HealthConnectRepositoryImpl(
+    private val clientProvider: HealthConnectClientProvider,
+    private val permissionManager: HealthConnectPermissionManager,
+) : HealthConnectRepository {
+
+    override suspend fun getActivity(date: LocalDate): Result<Activity> {
+        return get<ExerciseSessionRecord>(
+            startTime = date.dayStart(),
+            endTime = date.dayEnd(),
+        ).mapCatching { records ->
+            val walking = records.duration(ExerciseSessionRecord.EXERCISE_TYPE_WALKING)
+            val running = records.duration(ExerciseSessionRecord.EXERCISE_TYPE_RUNNING)
+            val other = records.duration() - walking - running
+
+            Activity(
+                date = date,
+                walking = walking,
+                running = running,
+                other = other,
+            )
+        }
+    }
+
+    override suspend fun getSleep(date: LocalDate): Result<Sleep> {
+        return get<SleepSessionRecord>(
+            startTime = date.minus(DatePeriod(days = 1)).atTime(hour = 12, minute = 0, second = 0),
+            endTime = date.atTime(hour = 12, minute = 0, second = 0),
+        ).mapCatching { records ->
+            val lightSleep = records.duration(SleepSessionRecord.STAGE_TYPE_LIGHT) +
+                    records.duration(SleepSessionRecord.STAGE_TYPE_REM) +
+                    records.duration(SleepSessionRecord.STAGE_TYPE_UNKNOWN)
+            val deepSleep = records.duration(SleepSessionRecord.STAGE_TYPE_DEEP)
+            val awake = records.duration(SleepSessionRecord.STAGE_TYPE_AWAKE)
+            val outOfBed = records.duration(SleepSessionRecord.STAGE_TYPE_OUT_OF_BED)
+
+            Sleep(
+                date = date,
+                lightSleep = lightSleep,
+                deepSleep = deepSleep,
+                awake = awake,
+                outOfBed = outOfBed,
+            )
+        }
+    }
+
+    override suspend fun getSteps(date: LocalDate): Result<Steps> {
+        return aggregate(
+            startTime = date.dayStart(),
+            endTime = date.dayEnd(),
+            metrics = setOf(StepsRecord.COUNT_TOTAL),
+        )
+            .mapCatching { records ->
+                val steps = records[StepsRecord.COUNT_TOTAL] as? Long ?: 0L
+
+                Steps(
+                    date = date,
+                    count = steps,
+                )
+            }
+    }
+
+    private suspend inline fun <reified T : Record> get(
+        startTime: LocalDateTime,
+        endTime: LocalDateTime,
+    ): Result<List<T>> = runCatching {
+        if (!permissionManager.hasPermission().first()) {
+            return@runCatching emptyList<T>()
+        }
+        val client = clientProvider().getOrThrow()
+
+        val response = client.readRecords(
+            ReadRecordsRequest(
+                recordType = T::class,
+                timeRangeFilter = TimeRangeFilter.between(
+                    startTime = startTime.toJavaLocalDateTime(),
+                    endTime = endTime.toJavaLocalDateTime(),
+                )
+            )
+        )
+
+        response.records
+    }
+
+    private suspend fun aggregate(
+        startTime: LocalDateTime,
+        endTime: LocalDateTime,
+        metrics: Set<AggregateMetric<Number>>,
+    ): Result<Map<AggregateMetric<Number>, Number>> = runCatching {
+        if (!permissionManager.hasPermission().first()) {
+            return@runCatching emptyMap()
+        }
+        val client = clientProvider().getOrThrow()
+
+        val response = client.aggregate(
+            AggregateRequest(
+                metrics = metrics,
+                timeRangeFilter = TimeRangeFilter.between(
+                    startTime = startTime.toJavaLocalDateTime(),
+                    endTime = endTime.toJavaLocalDateTime(),
+                ),
+            )
+        )
+
+        metrics.associateWith { metric -> (response[metric] ?: 0L) }
+    }
+
+    @JvmName("exerciseDuration")
+    private fun List<ExerciseSessionRecord>.duration(
+        @ExerciseSessionRecord.ExerciseTypes type: Int,
+    ): Duration {
+        return filter { it.exerciseType == type }
+            .duration()
+    }
+
+    private fun List<ExerciseSessionRecord>.duration(): Duration {
+        return sumOf { it.endTime.epochSecond - it.startTime.epochSecond }
+            .seconds
+    }
+
+    @JvmName("sleepDuration")
+    private fun List<SleepSessionRecord>.duration(
+        @SleepSessionRecord.StageTypes type: Int
+    ): Duration {
+        return map { record -> record.stages.filter { type == it.stage } }
+            .flatten()
+            .sumOf { it.endTime.epochSecond - it.startTime.epochSecond }
+            .seconds
+    }
+
+    private fun LocalDate.dayStart(): LocalDateTime =
+        atTime(hour = 0, minute = 0, second = 0)
+
+    private fun LocalDate.dayEnd(): LocalDateTime =
+        atTime(hour = 23, minute = 59, second = 59)
+}

--- a/app/src/main/java/com/feelsoftware/feelfine/fit/HealthConnectWrappers.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/fit/HealthConnectWrappers.kt
@@ -1,0 +1,266 @@
+package com.feelsoftware.feelfine.fit
+
+import android.content.Intent
+import com.feelsoftware.feelfine.fit.model.ActivityInfo
+import com.feelsoftware.feelfine.fit.model.Duration as LegacyDuration
+import androidx.activity.ComponentActivity
+import com.feelsoftware.feelfine.data.db.dao.ActivityDao
+import com.feelsoftware.feelfine.data.db.dao.SleepDao
+import com.feelsoftware.feelfine.data.db.dao.StepsDao
+import com.feelsoftware.feelfine.data.repository.UserRepository
+import com.feelsoftware.feelfine.fit.model.SleepInfo
+import com.feelsoftware.feelfine.fit.model.StepsInfo
+import com.feelsoftware.feelfine.utils.ActivityEngine
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
+import java.util.Calendar
+import java.util.Date
+import kotlin.time.Duration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+import timber.log.Timber
+
+@Suppress("DEPRECATION")
+@Deprecated("Migrate to HealthConnectPermissionManager")
+class HealthConnectFitPermissionManagerWrapper(
+    private val activityDao: ActivityDao,
+    activityEngine: ActivityEngine,
+    private val permissionManager: HealthConnectPermissionManager,
+    private val sleepDao: SleepDao,
+    private val stepsDao: StepsDao,
+    private val userRepository: UserRepository,
+) : FitPermissionManager {
+
+    init {
+        activityEngine.registerCallback(object : ActivityEngine.Callback {
+            override fun onActivityCreated(activity: ComponentActivity) {
+                permissionManager.init(activity)
+            }
+
+            override fun onActivityDestroyed() {
+                permissionManager.dispose()
+            }
+        })
+    }
+
+    override fun hasPermission(): Boolean {
+        return permissionManager.hasPermission().value
+    }
+
+    override fun hasPermissionObservable(): Observable<Boolean> {
+        return createRxObservable {
+            permissionManager.hasPermission()
+        }
+    }
+
+    override fun requestPermission(): Single<Boolean> {
+        return createRxSingle {
+            permissionManager.requestPermission()
+        }.flatMap { hasPermission ->
+            if (hasPermission) {
+                userRepository.getProfileLegacy()
+                    .firstOrError()
+                    .flatMapCompletable { profile ->
+                        userRepository.setProfileLegacy(profile.copy(isDemo = false))
+                    }
+                    // Clear cached mocked data
+                    .andThen(activityDao.delete())
+                    .andThen(sleepDao.delete())
+                    .andThen(stepsDao.delete())
+                    .subscribeOn(Schedulers.io())
+                    .andThen(Single.just(true))
+            } else {
+                Single.just(false)
+            }
+        }
+    }
+
+    override fun resetPermission(): Single<Boolean> {
+        return Single.just(false)
+    }
+
+    override fun onPermissionResult(requestCode: Int, resultCode: Int, data: Intent?) {}
+}
+
+@Deprecated("Migrate to HealthConnectRepository")
+class HealthConnectFitRepositoryWrapper(
+    private val repository: HealthConnectRepository,
+) : FitRepository {
+
+    override fun getSteps(startTime: Date, endTime: Date): Single<List<StepsInfo>> {
+        return getData(
+            startTime = startTime,
+            endTime = endTime,
+            fetcher = {
+                repository.getSteps(date = it)
+                    .mapCatching { steps ->
+                        StepsInfo(
+                            date = steps.date.toJavaDate(),
+                            count = steps.count.toInt(),
+                        )
+                    }
+            },
+            fallback = {
+                StepsInfo(
+                    date = it,
+                    count = 0,
+                )
+            },
+        )
+    }
+
+    override fun getSleep(startTime: Date, endTime: Date): Single<List<SleepInfo>> {
+        return getData(
+            startTime = startTime,
+            endTime = endTime,
+            fetcher = {
+                repository.getSleep(date = it)
+                    .mapCatching { sleep ->
+                        SleepInfo(
+                            date = sleep.date.toJavaDate(),
+                            lightSleep = sleep.lightSleep.toDuration(),
+                            deepSleep = sleep.deepSleep.toDuration(),
+                            awake = sleep.awake.toDuration(),
+                            outOfBed = sleep.outOfBed.toDuration(),
+                        )
+                    }
+            },
+            fallback = {
+                SleepInfo(
+                    date = endTime,
+                    lightSleep = LegacyDuration(0),
+                    deepSleep = LegacyDuration(0),
+                    awake = LegacyDuration(0),
+                    outOfBed = LegacyDuration(0),
+                )
+            },
+        )
+    }
+
+    override fun getActivity(startTime: Date, endTime: Date): Single<List<ActivityInfo>> {
+        return getData(
+            startTime = startTime,
+            endTime = endTime,
+            fetcher = {
+                repository.getActivity(date = it)
+                    .mapCatching { activity ->
+                        ActivityInfo(
+                            date = activity.date.toJavaDate(),
+                            activityUnknown = activity.other.toDuration(),
+                            activityWalking = activity.walking.toDuration(),
+                            activityRunning = activity.running.toDuration(),
+                        )
+                    }
+            },
+            fallback = {
+                ActivityInfo(
+                    date = endTime,
+                    activityUnknown = LegacyDuration(0),
+                    activityWalking = LegacyDuration(0),
+                    activityRunning = LegacyDuration(0),
+                )
+            },
+        )
+    }
+
+    private inline fun <reified T> getData(
+        startTime: Date,
+        endTime: Date,
+        crossinline fetcher: suspend (LocalDate) -> Result<T>,
+        crossinline fallback: (Date) -> T,
+    ): Single<List<T>> {
+        return createRxSingle {
+            var date = startTime.toLocalDate()
+            val days = endTime.toLocalDate()
+                .minus(startTime.toLocalDate()).days + 1
+            val results = List(days) {
+                async {
+                    fetcher(date.also { date = date.plus(DatePeriod(days = 1)) })
+                }
+            }.awaitAll()
+
+            // Return error only if all results failed, otherwise fallback to zero steps and log the error
+            if (results.all { it.isFailure }) {
+                return@createRxSingle Result.failure(results.first().exceptionOrNull()!!)
+            }
+
+            results
+                .mapIndexed { day, result ->
+                    result.getOrElse {
+                        Timber.e(it, "Failed to get ${T::class}")
+                        fallback(
+                            startTime.toLocalDate()
+                                .plus(DatePeriod(days = day))
+                                .toJavaDate()
+                        )
+                    }
+                }
+                .let { Result.success(it) }
+        }
+    }
+}
+
+private fun Date.toLocalDate(): LocalDate {
+    return Instant.fromEpochMilliseconds(time)
+        .toLocalDateTime(TimeZone.currentSystemDefault()).date
+}
+
+private fun LocalDate.toJavaDate(): Date {
+    return Calendar.getInstance().apply {
+        set(Calendar.DAY_OF_MONTH, dayOfMonth)
+        set(Calendar.MONTH, monthNumber - 1)
+        set(Calendar.YEAR, year)
+    }.time
+}
+
+private fun Duration.toDuration(): LegacyDuration {
+    return LegacyDuration(inWholeMinutes.toInt())
+}
+
+private fun <T : Any> createRxSingle(block: suspend CoroutineScope.() -> Result<T>): Single<T> {
+    return Single.create { emitter ->
+        val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+        coroutineScope.launch {
+            block()
+                .onSuccess { emitter.onSuccess(it) }
+                .onFailure { emitter.onError(it) }
+        }
+
+        emitter.setCancellable {
+            coroutineScope.cancel()
+        }
+    }
+}
+
+private fun <T : Any> createRxObservable(block: () -> Flow<T>): Observable<T> {
+    return Observable.create { emitter ->
+        val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+        block()
+            .onEach { emitter.onNext(it) }
+            .catch { emitter.onError(it) }
+            .launchIn(coroutineScope)
+
+        emitter.setCancellable {
+            coroutineScope.cancel()
+        }
+    }
+}

--- a/app/src/main/java/com/feelsoftware/feelfine/fit/model/StepsInfo.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/fit/model/StepsInfo.kt
@@ -1,6 +1,6 @@
 package com.feelsoftware.feelfine.fit.model
 
-import java.util.*
+import java.util.Date
 
 data class StepsInfo(
     val date: Date,

--- a/app/src/main/java/com/feelsoftware/feelfine/permission/PermissionRationaleView.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/permission/PermissionRationaleView.kt
@@ -1,0 +1,49 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.feelsoftware.feelfine.permission
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.feelsoftware.feelfine.R
+import com.feelsoftware.feelfine.ui.theme.FeelFineTheme
+
+@Composable
+fun PermissionRationaleView() {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(stringResource(R.string.app_name))
+                }
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(it)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+        ) {
+            Text(stringResource(R.string.health_connect_permission_details))
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun PermissionRationaleViewPreview() {
+    FeelFineTheme {
+        PermissionRationaleView()
+    }
+}

--- a/app/src/main/java/com/feelsoftware/feelfine/permission/PermissionsRationaleActivity.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/permission/PermissionsRationaleActivity.kt
@@ -1,0 +1,19 @@
+package com.feelsoftware.feelfine.permission
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import com.feelsoftware.feelfine.ui.theme.FeelFineTheme
+
+class PermissionsRationaleActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            FeelFineTheme {
+                PermissionRationaleView()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/feelsoftware/feelfine/sandbox/HealthConnectSandbox.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/sandbox/HealthConnectSandbox.kt
@@ -1,0 +1,110 @@
+package com.feelsoftware.feelfine.sandbox
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.feelsoftware.feelfine.fit.Activity
+import com.feelsoftware.feelfine.fit.HealthConnectPermissionManager
+import com.feelsoftware.feelfine.fit.HealthConnectRepository
+import com.feelsoftware.feelfine.fit.Sleep
+import com.feelsoftware.feelfine.fit.Steps
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+@Composable
+fun HealthConnectSandbox(
+    permissionManager: HealthConnectPermissionManager,
+    repository: HealthConnectRepository,
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val hasPermission by permissionManager.hasPermission().collectAsState()
+
+    var sleep by remember { mutableStateOf<Sleep?>(null) }
+    var steps by remember { mutableStateOf<Steps?>(null) }
+    var activity by remember { mutableStateOf<Activity?>(null) }
+
+    Scaffold {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(it)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(text = "Has permission $hasPermission")
+            Button(
+                enabled = !hasPermission,
+                onClick = {
+                    coroutineScope.launch {
+                        permissionManager.requestPermission()
+                    }
+                },
+            ) {
+                Text("Request permission")
+            }
+
+            Text(
+                modifier = Modifier.padding(top = 16.dp),
+                text = "Sleep $sleep"
+            )
+            Button(
+                onClick = {
+                    coroutineScope.launch {
+                        sleep = repository.getSleep(date = now()).getOrElse { null }
+                    }
+                },
+            ) {
+                Text("Get sleep")
+            }
+
+            Text(
+                modifier = Modifier.padding(top = 16.dp),
+                text = "Steps $steps"
+            )
+            Button(
+                onClick = {
+                    coroutineScope.launch {
+                        steps = repository.getSteps(date = now()).getOrElse { null }
+                    }
+                },
+            ) {
+                Text("Get steps")
+            }
+
+            Text(
+                modifier = Modifier.padding(top = 16.dp),
+                text = "Activity $activity"
+            )
+            Button(
+                onClick = {
+                    coroutineScope.launch {
+                        activity = repository.getActivity(date = now()).getOrElse { null }
+                    }
+                },
+            ) {
+                Text("Get activity")
+            }
+        }
+    }
+}
+
+private fun now(): LocalDate {
+    return Clock.System.now()
+        .toLocalDateTime(TimeZone.currentSystemDefault()).date
+}

--- a/app/src/main/java/com/feelsoftware/feelfine/sandbox/SandboxActivity.kt
+++ b/app/src/main/java/com/feelsoftware/feelfine/sandbox/SandboxActivity.kt
@@ -1,0 +1,48 @@
+package com.feelsoftware.feelfine.sandbox
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import com.feelsoftware.feelfine.fit.HealthConnectClientProvider
+import com.feelsoftware.feelfine.fit.HealthConnectClientProviderImpl
+import com.feelsoftware.feelfine.fit.HealthConnectPermissionManager
+import com.feelsoftware.feelfine.fit.HealthConnectPermissionManagerImpl
+import com.feelsoftware.feelfine.fit.HealthConnectRepository
+import com.feelsoftware.feelfine.fit.HealthConnectRepositoryImpl
+import com.feelsoftware.feelfine.ui.theme.FeelFineTheme
+
+class SandboxActivity : AppCompatActivity() {
+
+    private val clientProvider: HealthConnectClientProvider =
+        HealthConnectClientProviderImpl(
+            context = this,
+        )
+    private val permissionManager: HealthConnectPermissionManager =
+        HealthConnectPermissionManagerImpl(
+            clientProvider = clientProvider,
+        )
+    private val repository: HealthConnectRepository =
+        HealthConnectRepositoryImpl(
+            clientProvider = clientProvider,
+            permissionManager = permissionManager,
+        )
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        permissionManager.init(this)
+
+        setContent {
+            FeelFineTheme {
+                HealthConnectSandbox(
+                    permissionManager = permissionManager,
+                    repository = repository,
+                )
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        permissionManager.dispose()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,4 +61,5 @@
     <string name="error_alert_button">Close</string>
     <string name="demo_profile_badge">Demo</string>
     <string name="demo_profile_badge_description">You are not signed to Google Account and now you see demo steps, sleep and activity.\nOpen Profile tab and Sign In to Google to see your real data from Google Fit.</string>
+    <string name="health_connect_permission_details">FeelFine reads your fitness data (activity, sleep, steps) and keep that data locally, not shared to 3rd party services.</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,11 @@ firebaseCrashlytics = "3.0.2"
 googleApiClient = "1.30.11"
 googleApiServicesFitness = "v1-rev127-1.25.0"
 googleServices = "4.4.2"
+healthConnect = "1.1.0-alpha10"
 koin = "4.0.1"
 kotlin = "2.1.0"
 kotlinxCoroutines = "1.9.0"
+kotlinxDateTime = "0.6.1"
 ksp = "2.1.0-1.0.29"
 lifecycleViewmodelKtx = "2.8.7"
 listenablefuture = "9999.0-empty-to-avoid-conflict-with-guava"
@@ -55,9 +57,11 @@ fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragm
 google-api-client = { module = "com.google.api-client:google-api-client", version.ref = "googleApiClient" }
 google-api-client-android = { module = "com.google.api-client:google-api-client-android", version.ref = "googleApiClient" }
 google-api-services-fitness = { module = "com.google.apis:google-api-services-fitness", version.ref = "googleApiServicesFitness" }
+health-connect = { module = "androidx.health.connect:connect-client", version.ref = "healthConnect" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDateTime" }
 lifecycle-common-java8 = { module = "androidx.lifecycle:lifecycle-common-java8", version.ref = "lifecycleViewmodelKtx" }
 lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycleViewmodelKtx" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleViewmodelKtx" }


### PR DESCRIPTION
Migrate from Google Fit to Health Connect APIs.

> Google recommends keeping both your Google Fit Android API and Health Connect API integrations active while users migrate from one platform to the other. While Google has deprecated the Google Fit Android API, Google is aiming to turn down the API no sooner than June 30, 2025. This is to give users enough time to switch to Health Connect and continue their service.

Therefore if users have installed Health Connect app on their device, FeelFine will use Health Connect SDK. Otherwise Google Fit will be used instead, with no need to migrate to Health Connect until the next FeelFine release.